### PR TITLE
add rtm_ext_default_child_storage_storage_kill_version_2

### DIFF
--- a/test/runtimes/hostapi/src/lib.rs
+++ b/test/runtimes/hostapi/src/lib.rs
@@ -27,6 +27,7 @@ extern "C" {
     fn ext_default_child_storage_read_version_1(child: u64, key: u64, out: u64, offset: u32) -> u64;
     fn ext_default_child_storage_clear_version_1(child: u64, key: u64);
     fn ext_default_child_storage_storage_kill_version_1(child: u64);
+    fn ext_default_child_storage_storage_kill_version_2(child: u64, limit: u32) -> i32;
     fn ext_default_child_storage_exists_version_1(child: u64, key: u64) -> i32;
     fn ext_default_child_storage_clear_prefix_version_1(child: u64, key: u64);
     fn ext_default_child_storage_root_version_1(child: u64) -> u64;
@@ -238,6 +239,18 @@ sp_core::wasm_export_functions! {
             let _ = ext_default_child_storage_storage_kill_version_1(
                 child.as_re_ptr(),
             );
+        }
+    }
+
+    fn rtm_ext_default_child_storage_storage_kill_version_2(
+        child: Vec<u8>,
+        limit: u32
+    ) -> u32 {
+        unsafe {
+            ext_default_child_storage_storage_kill_version_2(
+                child.as_re_ptr(),
+                limit,
+            ) as u32
         }
     }
 


### PR DESCRIPTION
add `rtm_ext_default_child_storage_storage_kill_version_2` reflect call to test host api.  Note:  spec shows this returning i8, but I'm modeling this after `rtm_ext_default_child_storage_exists_version_1` which the spec says also returns i8, but has been implemented returning u32.  Let me know if I should implement this differently.